### PR TITLE
Add 'Share via gist' option for short share links

### DIFF
--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -6,7 +6,7 @@
   import { python } from "@codemirror/lang-python";     // Imports Python syntax highlighting
   import { linter, lintGutter } from "@codemirror/lint"; // Imports linting support
   import { fade } from 'svelte/transition'; // Imports smooth transition for a pop-up message
-  import { parseLintErrors } from '../utils';
+  import { parseLintErrors, extractGistId } from '../utils';
   import JSZip from "jszip"; // Import JSZip for creating zip files
   import { examples } from  '../examples.js';
   import LZString from 'lz-string';
@@ -110,6 +110,26 @@ show(model, result)`,
     }).catch(() => {
       alert("Share link:\n" + url);
     });
+  }
+
+  async function shareViaGist() {
+    const input = window.prompt(
+      "Paste a public GitHub gist URL (the gist must contain your code):"
+    );
+    if (!input) return;
+    const id = extractGistId(input);
+    if (!id) {
+      alert("Couldn't recognise that as a gist URL.");
+      return;
+    }
+    const url = `${window.location.origin}${window.location.pathname}?gist=${id}`;
+    try {
+      await navigator.clipboard.writeText(url);
+      shareToast = true;
+      setTimeout(() => { shareToast = false; }, 3000);
+    } catch {
+      alert("Share link:\n" + url);
+    }
   }
 
   function exportCode() {
@@ -248,7 +268,28 @@ show(model, result)`,
     }
   }
 
-  onMount(() => {
+  async function loadGistIntoTabs(gistId) {
+    const res = await fetch(`https://api.github.com/gists/${gistId}`);
+    if (!res.ok) throw new Error(`gist fetch failed: ${res.status}`);
+    const gist = await res.json();
+    const files = gist.files || {};
+    const filenames = Object.keys(files);
+    if (filenames.length === 0) throw new Error("gist has no files");
+
+    const loaded = {};
+    for (const name of filenames) {
+      const f = files[name];
+      // Files >~1MB are truncated inline and must be re-fetched from raw_url
+      loaded[name] = f.truncated && f.raw_url
+        ? await (await fetch(f.raw_url)).text()
+        : (f.content ?? "");
+    }
+    tabs = loaded;
+    activeTab = filenames[0];
+    code = tabs[activeTab];
+  }
+
+  onMount(async () => {
       // Load linting preference from localStorage
     const lintPref = localStorage.getItem('linting_enabled');
     if (lintPref !== null) {
@@ -263,8 +304,16 @@ show(model, result)`,
 
     // Check for shared workspace in URL params
     const params = new URLSearchParams(window.location.search);
+    const gistId = params.get('gist');
     const sharedActive = params.get('active');
-    if (sharedActive) {
+    if (gistId) {
+      try {
+        await loadGistIntoTabs(gistId);
+      } catch (e) {
+        console.error('Failed to load gist:', e);
+        getTabData();
+      }
+    } else if (sharedActive) {
       try {
         const sharedTabs = {};
         let i = 0;
@@ -531,6 +580,10 @@ show(model, result)`,
       <button on:click={shareCode}
         class="nav-btn">
         Share
+      </button>
+      <button on:click={shareViaGist}
+        class="nav-btn">
+        Share via gist
       </button>
     </nav>
   </header>

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -13,6 +13,16 @@ export   function mapSeverity(errorCode) {
   }
 }
 
+// Extracts a GitHub gist ID from a pasted URL, a scheme-less URL, or a bare ID.
+// Returns null if no plausible hex ID is found.
+export function extractGistId(input) {
+  if (!input) return null;
+  const trimmed = String(input).trim().split(/[?#]/)[0].replace(/\/+$/, '');
+  if (!trimmed) return null;
+  const candidate = trimmed.split('/').pop();
+  return /^[0-9a-f]{20,}$/i.test(candidate) ? candidate : null;
+}
+
 // Parses the lint output and extracts the line number, column number, error code, and message
 export function parseLintErrors(lintOutput, doc) {
   const errors = [];

--- a/frontend/tests-vitest/page.test.js
+++ b/frontend/tests-vitest/page.test.js
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/svelte';
 import Page from '../src/routes/+page.svelte';
-import { mapSeverity, parseLintErrors } from '../src/utils.js'; // Import functions
+import { mapSeverity, parseLintErrors, extractGistId } from '../src/utils.js'; // Import functions
 import { vi } from 'vitest';
 
 
@@ -170,6 +170,19 @@ describe('Page Component', () => {
     expect(mapSeverity('W001')).toBe('warning');
     expect(mapSeverity('I001')).toBe('info');
     expect(mapSeverity('unknown')).toBe('info');
+  });
+
+  test('extractGistId function', () => {
+    const id = 'aa11bb22cc33dd44ee55ff6677889900';
+    expect(extractGistId(`https://gist.github.com/someuser/${id}`)).toBe(id);
+    expect(extractGistId(`https://gist.github.com/${id}`)).toBe(id);
+    expect(extractGistId(`gist.github.com/someuser/${id}/`)).toBe(id);
+    expect(extractGistId(`https://gist.github.com/someuser/${id}#file-foo-py`)).toBe(id);
+    expect(extractGistId(`https://gist.github.com/someuser/${id}?foo=bar`)).toBe(id);
+    expect(extractGistId(id)).toBe(id);
+    expect(extractGistId('https://example.com/foo')).toBeNull();
+    expect(extractGistId('')).toBeNull();
+    expect(extractGistId(null)).toBeNull();
   });
 
   test('parseLintErrors function', () => {


### PR DESCRIPTION
## Summary
- Adds a **Share via gist** button next to the existing Share button. Prompts for a public GitHub gist URL, validates it, and copies a short `?gist=<id>` link to the clipboard.
- On load, if `?gist=<id>` is present, the playground fetches the gist from the public GitHub API and maps each file in the gist to a tab. Falls back to localStorage on any error (network, 404, malformed gist), same shape as the existing base64 decode failure path.
- Handles GitHub's >1MB inline truncation by re-fetching from `raw_url`.
- Pure frontend change — gists API is CORS-enabled, no backend or token needed.

## Test plan
- [x] `npm test` — 10/10 passing, including new `extractGistId` unit test (covers full URL, scheme-less URL, bare ID, `?`/`#` suffixes, invalid input).
- [ ] Click **Share via gist**, paste a real public gist URL with multiple files, confirm `?gist=<id>` link is copied and the toast appears.
- [ ] Open the copied link in a fresh tab — confirm files load as tabs with the first file active.
- [ ] Paste only the bare hex ID — confirm it still produces a valid link.
- [ ] Paste a non-gist URL — confirm the alert appears and no link is generated.
- [ ] Open `?gist=<bogus-id>` directly — confirm graceful fall-through to localStorage tabs (no blank UI), error logged.
- [ ] Confirm existing base64 share link (`?active=...&tab0=...`) still loads correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)